### PR TITLE
fix(ts):修改导入autoExpose包，没有找到对应的ts声明

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ After using the script setup syntax, the export needs to be processed manually. 
 main.ts
 ```ts
 import { createApp } from 'vue'
-import autoExpose from 'unplugin-vue-setup-extend-plus/src/client/index'
+import autoExpose from 'unplugin-vue-setup-extend-plus/dist/client/index'
 import App from './App.vue'
 
 createApp(App).use(autoExpose).mount('#app')

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
       "require": "./dist/types.cjs",
       "import": "./dist/types.js"
     },
+    "./dist/client/index": {
+      "types": "./dist/client/index.d.ts",
+      "require": "./dist/client/index.cjs",
+      "import": "./dist/client/index.js"
+    },
     "./*": "./*"
   },
   "typesVersions": {


### PR DESCRIPTION
当我尝试在vue3中引入autoExpose的时候，会出现找不到ts声明的错误。


<img width="770" alt="image" src="https://github.com/chenxch/unplugin-vue-setup-extend-plus/assets/79642899/eaecc668-87c4-4889-9c99-771d6b5def48">
